### PR TITLE
remove graphicsmagic dep

### DIFF
--- a/waffle-scm-1.rockspec
+++ b/waffle-scm-1.rockspec
@@ -2,13 +2,13 @@ package = 'waffle'
 version = 'scm-1'
 
 source = {
-   url = 'git://github.com/benglard/waffle',
+   url = 'git://github.com/christopher5106/waffle',
 }
 
 description = {
    summary = 'Fast, asynchronous web framework for Lua/Torch',
    detailed = [[Waffle is a fast, asynchronous, express-inspired web framework for Lua/Torch]],
-   homepage = 'https://github.com/benglard/waffle'
+   homepage = 'https://github.com/christopher5106/waffle'
 }
 
 dependencies = {

--- a/waffle/request.lua
+++ b/waffle/request.lua
@@ -1,4 +1,3 @@
-local ffi = require 'ffi'
 local async = require 'async'
 local encodings = require 'waffle.encodings'
 local gmOk, gm = pcall(require, 'image')
@@ -34,9 +33,13 @@ end
 
 local _totensor = function(self, ...)
    if gmOk then
-     local b = torch.ByteTensor(string.len(self.data))
-     ffi.copy(b:data(), self.data, b:size(1))
-     return image.decompress(b, 3, 'float')
+     local data = torch.ByteTensor(torch.ByteStorage():string(self.data))
+     local ok, img = pcall(image.decompress, data)
+     if ok then
+       return img
+     else
+       return nil
+     end
    else
       return nil
    end

--- a/waffle/request.lua
+++ b/waffle/request.lua
@@ -1,6 +1,7 @@
+local ffi = require 'ffi'
 local async = require 'async'
 local encodings = require 'waffle.encodings'
-local gmOk, gm = pcall(require, 'graphicsmagick')
+local gmOk, gm = pcall(require, 'image')
 local afs = async.fs
 local http_codes = async.http.codes
 
@@ -33,9 +34,9 @@ end
 
 local _totensor = function(self, ...)
    if gmOk then
-      return gm.Image()
-         :fromString(self.data)
-         :toTensor(...)
+     local b = torch.ByteTensor(string.len(self.data))
+     ffi.copy(b:data(), self.data, b:size(1))
+     return image.decompress(b, 3, 'float')
    else
       return nil
    end


### PR DESCRIPTION
Works on Mac os and Ubuntu Docker kaixhin/cuda-torch:latest

I was not able to install graphicsmagic on kaixhin/cuda-torch:latest.

So I think it is a better solution to use the package image than graphicsmagick
